### PR TITLE
fix: 초대장 테두리 rounded 수정

### DIFF
--- a/src/components/CompleteLayout.tsx
+++ b/src/components/CompleteLayout.tsx
@@ -58,7 +58,7 @@ export default function CompleteLayout({ type, imageUrl, imageName }: propsType)
           <div className="absolute top-[44px] z-30 flex h-[40px] w-[240px] items-center justify-center rounded-[10px] border-[3px] border-solid border-[#FFC9D4] bg-[#FEEFF4] shadow-blossom-pink drop-shadow-pageTitle">
             벚꽃 초대장
           </div>
-          <div className="relative z-20 mt-[66px] flex h-[300px] w-[320px] items-center justify-center overflow-hidden rounded-[10px] border border-solid border-pink-200 bg-white shadow-md">
+          <div className="relative z-20 mt-[66px] flex h-[300px] w-[320px] items-center justify-center overflow-hidden rounded-[8px] bg-white shadow-md">
             <div className="relative h-full w-full">
               {imageUrl !== undefined && <Image src={imageUrl} alt="image" fill />}
             </div>


### PR DESCRIPTION
## 작업내용
- 부모 div border 없애고 이미지 자체의 테두리 활용
- 자연스러워 보이도록 radius 8px 로 변경

## 참고 이미지
<img width="554" alt="스크린샷 2023-03-09 오전 12 52 21" src="https://user-images.githubusercontent.com/88193063/223763529-e2046198-24a1-4975-94dc-b1c14c04329c.png">
