### PR TITLE
refactor : next script 사용한 최적화 (First Contentful Paint 1.8s -> 0.3s)

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -5,11 +5,6 @@ export default function Document() {
     <Html lang="en">
       <Head>
         <link rel="shortcut icon" href="/favicon.ico" />
-        <script
-          src="https://t1.kakaocdn.net/kakao_js_sdk/2.1.0/kakao.min.js"
-          integrity="sha384-dpu02ieKC6NUeKFoGMOKz6102CLEWi9+5RQjWSV0ikYSFFd8M3Wp2reIcquJOemx"
-          crossOrigin="anonymous"
-        ></script>
       </Head>
       <body>
         <Main />

--- a/src/components/CompleteLayout.tsx
+++ b/src/components/CompleteLayout.tsx
@@ -3,6 +3,7 @@ import { copyLink } from '@/pages/api/share';
 import { useRouter } from 'next/router';
 import Image from 'next/image';
 import ToastMessage from '@/src/components/ToastMessage';
+import Script from 'next/script';
 
 type propsType = {
   type: 'complete' | 'receive';
@@ -29,15 +30,11 @@ export default function CompleteLayout({ type, imageUrl, imageName }: propsType)
     }
   };
 
-  useEffect(() => {
-    try {
-      if (!window.Kakao.isInitialized(process.env.NEXT_PUBLIC_KAKAO_KEY)) {
-        window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_KEY);
-      }
-    } catch (e) {
-      console.error(e);
+  const kakaoInit = () => {
+    if (!window.Kakao.isInitialized(process.env.NEXT_PUBLIC_KAKAO_KEY)) {
+      window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_KEY);
     }
-  }, []);
+  };
 
   const shareKakao = () => {
     window.Kakao.Share.sendCustom({
@@ -51,6 +48,11 @@ export default function CompleteLayout({ type, imageUrl, imageName }: propsType)
   return (
     <div className="h-full w-full">
       <div className="flex w-full justify-center">
+        <Script
+          strategy="afterInteractive"
+          src="https://t1.kakaocdn.net/kakao_js_sdk/2.1.0/kakao.min.js "
+          onLoad={kakaoInit}
+        />
         <ToastMessage
           popToastMsg={popToastMsg}
           setPopToastMsg={setPopToastMsg}


### PR DESCRIPTION
## First Contentful Paint 최적화 1.8s -> 0.3s


### 문제

- 카카오 공유하기를 사용할 때 필요한 JS SDK를 Script로 불러와 사용중이었는데, 맨 처음 시작할 때부터 불러와 첫 렌더링이 오래걸리는 문제가 있었습니다.

![스크린샷 2023-03-17 오전 12 21 37](https://user-images.githubusercontent.com/59612529/225673586-405c4f62-0036-455d-917e-0205c06f923b.png)

![image](https://user-images.githubusercontent.com/59612529/225673209-1d6dafbc-effa-47e6-8d94-5f2decf3184a.png)

### 해결방법

- NextJS 에서 제공하는 `Script` 를 사용하였습니다.
- `document.tsx` 에 있었던 script를 삭제 후, 실제로 `카카오 공유하기` 버튼이 있는 `CompleteLayout.tsx` 에 Script를 넣었습니다.

```tsx
//CompleteLayouy.tsx
        <Script
          strategy="afterInteractive"
          src="https://t1.kakaocdn.net/kakao_js_sdk/2.1.0/kakao.min.js "
          onLoad={kakaoInit}
        />
```

시간이 1.5초 가량 줄어든 것을 확인 할 수있습니다 !

![스크린샷 2023-03-17 오전 12 21 48](https://user-images.githubusercontent.com/59612529/225673861-1f306b23-724a-48bd-b51e-0d3a9d493169.png)

