### PR TITLE
fix: 나만의 초대장 타이틀 height 추가

### DIFF
--- a/src/components/Creation/PageTitle/index.tsx
+++ b/src/components/Creation/PageTitle/index.tsx
@@ -2,7 +2,7 @@ export default function PageTitle() {
   return (
     <div className="flex w-full justify-center">
       <div
-        className={`z-10 w-60	 translate-y-1/2 rounded-[10px] border-[3px] border-solid border-blossom-pink  bg-blossom-lightPink py-3 text-center text-xl shadow-blossom-pink drop-shadow-pageTitle`}
+        className={`z-10 flex h-10 w-60 translate-y-1/2 items-center justify-center rounded-[10px]  border-[3px] border-solid border-blossom-pink bg-blossom-lightPink py-3 text-center text-xl shadow-blossom-pink drop-shadow-pageTitle`}
       >
         나만의 벚꽃 초대장
       </div>


### PR DESCRIPTION
따로 height 값이 정해져있지 않아 추가했습니다.
---

<img width="1080" alt="스크린샷 2023-03-17 오후 1 50 00" src="https://user-images.githubusercontent.com/59612529/225815464-45311842-0af6-43b5-9389-befbfdd8b166.png">
