### PR TITLE
fix: 공유하기 버튼 쿼리로 받아오기

### DIFF
--- a/src/components/CompleteLayout.tsx
+++ b/src/components/CompleteLayout.tsx
@@ -17,6 +17,7 @@ export default function CompleteLayout({ type, imageUrl, imageName }: propsType)
   const [checkClickedBtn, setCheckClickedBtn] = useState({ copy: false, save: false });
   const router = useRouter();
   const innerHeight = window.innerHeight;
+  const { img: completePageQuery } = router.query;
 
   const handleClickShareBtn = () => {
     setToastType('copy');
@@ -41,7 +42,7 @@ export default function CompleteLayout({ type, imageUrl, imageName }: propsType)
     window.Kakao.Share.sendCustom({
       templateId: 91057,
       templateArgs: {
-        imageName: `${imageName}`,
+        completePageQuery: `${completePageQuery} `,
       },
     });
   };


### PR DESCRIPTION
## 문제점
기존에는 completeLayout으로 넘어오는 imageName을 받아 사용했는데, 그렇게 되면 초대장 받는 페이지에서 카카오톡 공유하기 클릭 시 에러 가 발생합니다.

## 수정사항
팀원들의 말대로 query를 받아 공유하기 버튼이 동작하도록 수정하였습니다.


### 변경전
```tsx
const shareKakao = () => {
    window.Kakao.Share.sendCustom({
      templateId: 91057,
      templateArgs: {
        imageName: `${imageName}`, //기존 : imageName을 받았다.
      },
    });
  };
```

### 변경후

```tsx
import { useRouter } from 'next/router';
const { img: completePageQuery } = router.query;

const shareKakao = () => {
    window.Kakao.Share.sendCustom({
      templateId: 91057,
      templateArgs: {
        completePageQuery: `${completePageQuery} `, //쿼리를 받습니다!
      },
    });
  };
```