### PR TITLE
fix: 카카오톡 공유하기 띄어쓰기 수정

### DIFF
--- a/src/components/CompleteLayout.tsx
+++ b/src/components/CompleteLayout.tsx
@@ -42,7 +42,7 @@ export default function CompleteLayout({ type, imageUrl, imageName }: propsType)
     window.Kakao.Share.sendCustom({
       templateId: 91057,
       templateArgs: {
-        completePageQuery: `${completePageQuery} `,
+        completePageQuery: `${completePageQuery}`,
       },
     });
   };


### PR DESCRIPTION
작성한 코드에 띄어쓰기가 들어가, 공유하기 받은 파일에 %20 이 추가되어 제대로 나오지 않는 오류가 있습니다.
```tsx
  const shareKakao = () => {
    window.Kakao.Share.sendCustom({
      templateId: 91057,
      templateArgs: {
        completePageQuery: `${completePageQuery} `, //여기 Query} 뒤에 띄어쓰기 하나 때문에..
      },
    });
  };
```