### PR TITLE
Fix/intro/optimization : 인트로 페이지 최적화

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,5 +11,6 @@ module.exports = withBundleAnalyzer({
     contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
     domains: ['firebasestorage.googleapis.com'],
     dangerouslyAllowSVG: true,
+    formats: ['image/avif', 'image/webp'],
   },
 });

--- a/pages/intro/IntroComponent.tsx
+++ b/pages/intro/IntroComponent.tsx
@@ -15,7 +15,7 @@ export default function IntroComponent() {
   return (
     <div className="flex w-[89%] flex-col items-center justify-center">
       <div className="relative flex w-[100%] items-center justify-center">
-        <Image src={Bg} alt="Bg" className="w-[100%] rounded-xl" />
+        <Image src={Bg} alt="Bg" priority />
         <Image
           src={Logo}
           alt="Logo"

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,13 +1,16 @@
 import localFont from '@next/font/local';
+import { Gamja_Flower } from '@next/font/google';
 
-const gamjaFlower = localFont({
-  src: '../../public/fonts/GamjaFlower-Regular.ttf',
-  variable: '--font-jamjaFlower',
+const gamjaFlower = Gamja_Flower({
+  weight: '400',
+  subsets: ['latin'],
+  variable: '--font-gamjaFlower',
 });
 
 const pretendard = localFont({
   src: '../../public/fonts/Pretendard-Regular.woff',
   variable: '--font-pretendard',
+  preload: false,
 });
 
 export default function Layout({ children }: { children: React.ReactNode }) {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -70,7 +70,7 @@ module.exports = {
         },
       },
       fontFamily: {
-        sans: ['var(--font-jamjaFlower)', ...fontFamily.sans],
+        sans: ['var(--font-gamjaFlower)', ...fontFamily.sans],
         pretendard: ['var(--font-pretendard)'],
       },
     },


### PR DESCRIPTION
## 1.  LCP priority 지정

<img width="743" alt="스크린샷 2023-03-20 오전 1 54 08" src="https://user-images.githubusercontent.com/59612529/226192302-c2b343a7-5917-49a7-ad3b-b5f72b5bbce3.png">

- 라이트 하우스 측정 시, 해당 bg의 LCP (Largest Contentful Paint) 가 매우 저조한 수치를 보이고 있음을 알 수 있습니다.
- LCP란 무엇일까요? NEXTJS 공식 홈페이지에 설명이 있습니다. [LCP -NEXTJS](https://nextjs.org/learn/seo/web-performance/lcp)
- LCP(Large Contentful Paint) 메트릭은 페이지의 로드 성능을 확인합니다. LCP는 페이지에서 가장 큰 요소를 뷰포트 내에 표시하는 데 걸리는 시간을 측정합니다. 이것은 페이지의 주요 영역을 차지하는 큰 텍스트 블록, 비디오 또는 이미지일 수 있습니다.
- 이 LCP를 저조하게 만드는 컨텐츠를 어떻게 수정하면 될까요? 바로 **priority**를 사용해주면 됩니다.
- NEXT 공식문서에서는 LCP에 문제가 되는 이미지에 priority를 추가해주면 된다고 하는데요. [priority-NEXTJS](https://nextjs.org/docs/basic-features/image-optimization#priority)
- 문제 되는 이미지에 priority를 작성 후 라이트하우스를 한번 더 확인했습니다.
```<Image src={Bg} alt="Bg" priority />```
<img width="743" alt="스크린샷 2023-03-20 오전 1 54 37" src="https://user-images.githubusercontent.com/59612529/226192655-331b01bd-9b52-4e3d-a9d8-5d17ecf660fa.png">
- 괄목할만한 수치는 아니지만, 차근차근 최적화가 되고 있다는 것을 알 수 있습니다.

## 2. gamjaFlower 폰트 local 불러오기에서 next/font로 불러오기
- 기존 gamjaFlower는 로컬에서 불러오는 형태로 되어 있었습니다.
- 해당 폰트는 구글폰트에 있는 폰트로, next에서 제공하는 next/font를 사용하면 더 나은 최적화를 보여줄 것이라 생각하여 수정하였습니다.


## 3. pretendard 폰트 preload: false 추가
- 레이아웃에는 감자플라워와 프리텐다드 폰트가 전체에 뿌려지게 되는데요.
- 맨 처음 intro에선 프리텐다드 폰트를 사용하지 않으나 불러와지게 되어 성능을 떨어뜨리는 요소로 보였습니다.
- NextJS 공식문서에는 폰트 옵션 중 preload가 있는 것을 알려주었는데요. preload false는 말그대로 처음부터 가져오지 않는 것으로 보입니다. 이를 적용해보았습니다.  [next/font/preload-NEXTJS](https://nextjs.org/docs/api-reference/next/font#preload)


### 추가전
<img width="743" alt="스크린샷 2023-03-20 오전 2 13 59" src="https://user-images.githubusercontent.com/59612529/226194725-7e32948a-55e2-4f4c-b6a4-4da2c7f9b654.png">

### 추가후
<img width="743" alt="스크린샷 2023-03-20 오전 2 15 01" src="https://user-images.githubusercontent.com/59612529/226194748-a68c80b5-bd29-4ae6-9902-0cb75a3afc1e.png">



이렇게 일부 내용을 수정하여 조금의 최적화를 할 수 있었습니다.
더 줄이는 방법을 계속 찾아보고 적용하여 성과가 나오면 추가적으로 PR을 할 수 있도록 하겠습니다.
