### PR TITLE
feat/creation optimizing

### DIFF
--- a/src/components/Creation/Display/index.tsx
+++ b/src/components/Creation/Display/index.tsx
@@ -179,7 +179,7 @@ export default function Display(props: DisplayProps) {
         </div>
         <div
           id="display"
-          className="absolute flex h-full w-screen items-center justify-center overflow-hidden web:w-[380px]"
+          className="absolute flex h-full w-[440px] items-center justify-center overflow-hidden"
           onMouseMove={handleMouseMove}
           onTouchMove={handleMouseMove}
         >

--- a/src/components/Creation/Display/index.tsx
+++ b/src/components/Creation/Display/index.tsx
@@ -6,6 +6,7 @@ import { MESSAGE } from '@/src/constants/message';
 import { MouseEvent, MutableRefObject, useCallback, useEffect, useRef, useState } from 'react';
 import SelectionModal from '../../SelectionModal';
 import { handleKeyDown, handleTextBlur, handleTextFocus } from './staticFunctions';
+import Image from 'next/image';
 
 export type CategoryTypes = 'character' | 'sticker';
 export type ItemObjectType = {
@@ -156,12 +157,14 @@ export default function Display(props: DisplayProps) {
         id="outerDisplay"
         ref={displayRef}
         className="relative flex h-[300px] w-[320px] items-center justify-center overflow-hidden rounded-lg border border-solid border-[#FDC7D4]"
-        style={{
-          'background-image': `url(/backgrounds/${selectedBackground}.svg)`,
-          'background-size': 'cover',
-        }}
-        priority
       >
+        <Image
+          src={`/backgrounds/${selectedBackground}.svg`}
+          alt={'display'}
+          className="object-cover"
+          fill
+          priority
+        />
         <div
           onClick={handleQuestionClick}
           className="absolute top-[10px] right-[10px] z-10 cursor-pointer"


### PR DESCRIPTION
1번
- display의 배경이 기존에는 div의 background-image로 설정했었습니다.
- 이걸 Next Image로 바꾸고 priority를 적용해봤습니다.

2번
- 캐릭터/스티커 사이즈가 커지면서 예전에 오른쪽 끄트머리에 가면 작아지던 이슈가 다시 생겼습니다.
- display 사이즈를 키워 이 에러를 잡았습니다.