### PR TITLE
feat: creation page dynamic import 해제

### DIFF
--- a/pages/creation/index.tsx
+++ b/pages/creation/index.tsx
@@ -1,8 +1,6 @@
 import { GetStaticPropsContext } from 'next';
-import dynamic from 'next/dynamic';
 import Head from 'next/head';
-
-const CreationComponent = dynamic(() => import('./CreationComponent'));
+import CreationComponent from './CreationComponent';
 
 const Creation = () => {
   return (


### PR DESCRIPTION
- SSR 또는 SSG 처리하는 페이지에는 dynamic import를 적용하면 미리 HTML, CSS 파일을 준비하는 장점이 사라집니다.
- dynamic import 처리를 하니 creation page가 SSG 처리를 하지 못해 보통 import로 바꿉니다.